### PR TITLE
protect test code

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -3,3 +3,11 @@ description `A "tagged union" implementation with transparent operator forwardin
 authors "Sönke Ludwig"
 copyright "Copyright © 2015, Sönke Ludiwg"
 license "BSL-1.0"
+
+configuration "default" {
+
+}
+
+configuration "unittest" {
+    versions "Test_taggedalgebraic"
+}

--- a/source/taggedalgebraic.d
+++ b/source/taggedalgebraic.d
@@ -1,6 +1,6 @@
 /**
  * Algebraic data type implementation based on a tagged union.
- * 
+ *
  * Copyright: Copyright 2015-2016, Sönke Ludwig.
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sönke Ludwig
@@ -232,7 +232,7 @@ unittest
 	Tagged taggedAny = taggedInt;
 	taggedAny = taggedString;
 	taggedAny = taggedFoo;
-	
+
 	// Check type: Tagged.Kind is an enum
 	assert(taggedInt.kind == Tagged.Kind.i);
 	assert(taggedString.kind == Tagged.Kind.str);
@@ -370,7 +370,7 @@ unittest {
 	static union U {
 		S s;
 	}
-	
+
 	auto u = TaggedAlgebraic!U(S.init);
 	const uc = u;
 	immutable ui = cast(immutable)u;
@@ -427,7 +427,7 @@ unittest {
 	static assert( is(typeof(ta.testI())));
 }
 
-version (unittest) {
+version (unittest) version (Test_taggedalgebraic) {
 	// test recursive definition using a wrapper dummy struct
 	// (needed to avoid "no size yet for forward reference" errors)
 	template ID(What) { alias ID = What; }


### PR DESCRIPTION
because otherwise, when `taggedalgebraic` is depended on by another project and that project compiles its unittest build with `dub test`, there is an inconsistency between the two versions of the code: the one seen in the import (compiled with `-unittest`) and the one linked in as the library (not compiled with `-unittest`.

In general I think that either `dub` must treat `-unittest` like other versions (propagated down to dependencies) or people should get in the habit of protecting any `version (unittest)` code like I do in this PR.