### PR TITLE
Refactor the TaggedUnion API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ taggedAny = taggedFoo;
 // Default initializes to the first field
 TUnion taggedDef;
 assert(taggedDef.isCount);
-assert(taggedDef.getCount == int.init);
+assert(taggedDef.countValue == int.init);
 
 // Check type: TUnion.Kind is an enum
 assert(taggedInt.kind == TUnion.Kind.count);
@@ -53,24 +53,30 @@ assert(taggedFoo.isFoo);
 assert(taggedAny.isFoo);
 
 // Set to a different type
-taggedAny.setStr("bar");
+taggedAny.strValue("bar");
 assert(taggedAny.isStr);
-assert(taggedAny.getStr() == "bar");
+assert(taggedAny.strValue == "bar");
 
 // Modify contained value by reference
-taggedAny.getStr() = "baz";
-assert(taggedAny.getStr() == "baz");
+taggedAny.strValue = "baz";
+assert(taggedAny.strValue == "baz");
 
 // In addition to the getter, the contained value can be extracted using get!()
 // or by casting
-assert(taggedInt.get!(TUnion.Kind.count) == 5);
-assert(taggedInt.get!int == 5);
+assert(taggedInt.value!(TUnion.Kind.count) == 5);
+assert(taggedInt.value!int == 5);
 assert(cast(byte)taggedInt == 5);
 
 // Multiple kinds of the same type are supported
 taggedAny.setOffset(5);
 assert(taggedAny.isOffset);
-assert(taggedAny.isCount);
+assert(!taggedAny.isCount);
+
+// Unique types can also be set directly
+taggedAny = "foo";
+assert(taggedAny.isStr);
+taggedAny = TUnion(Foo.init);
+assert(taggedAny.isFoo);
 ```
 
 

--- a/source/taggedalgebraic/taggedalgebraic.d
+++ b/source/taggedalgebraic/taggedalgebraic.d
@@ -652,12 +652,12 @@ unittest {
 */
 ref inout(T) get(T, U)(ref inout(TaggedAlgebraic!U) ta)
 {
-	return ta.m_union.get!T;
+	return ta.m_union.value!T;
 }
 /// ditto
 inout(T) get(T, U)(inout(TaggedAlgebraic!U) ta)
 {
-	return ta.m_union.get!T;
+	return ta.m_union.value!T;
 }
 
 @nogc @safe nothrow unittest {
@@ -1035,7 +1035,7 @@ private string generateConstructors(U)()
 		ret ~= q{
 			this(UnionType.FieldTypeByName!"%1$s" value)
 			{
-				static if (isUnionType!(UnionType.FieldTypeByName!"%1$s"))
+				static if (isUnitType!(UnionType.FieldTypeByName!"%1$s"))
 					m_union.set!(Kind.%1$s)();
 				else
 					m_union.set!(Kind.%1$s)(value);
@@ -1043,7 +1043,7 @@ private string generateConstructors(U)()
 
 			void opAssign(UnionType.FieldTypeByName!"%1$s" value)
 			{
-				static if (isUnionType!(UnionType.FieldTypeByName!"%1$s"))
+				static if (isUnitType!(UnionType.FieldTypeByName!"%1$s"))
 					m_union.set!(Kind.%1$s)();
 				else
 					m_union.set!(Kind.%1$s)(value);
@@ -1060,7 +1060,7 @@ private string generateConstructors(U)()
 					foreach (i, n; TaggedUnion!U.fieldNames) {
 						static if (is(UnionType.FieldTypeByName!"%1$s" == UnionType.FieldTypes[i])) {
 							case __traits(getMember, Kind, n):
-								static if (isUnionType!(UnionType.FieldTypes[i]))
+								static if (isUnitType!(UnionType.FieldTypes[i]))
 									m_union.set!(__traits(getMember, Kind, n))();
 								else m_union.set!(__traits(getMember, Kind, n))(value);
 								return;


### PR DESCRIPTION
- Add constructors and assignment operators for unique types
- Rename field getters to fooValue and value!() to enable sane property syntax and to avoid confusion when modifying the returned reference
- Fix misnomer "isUnionType" instead of "isUnitType"