### PR TITLE
Use a more modern .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,32 @@
+# Compiled Object files
+*.o
+*.obj
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Compiled Static libraries
+*.a
+*.lib
+
+# Executables
+*.exe
+build/
+
+# DUB
 .dub
-taggedalgebraic-test-library
-taggedalgebraic-test-library.*
+docs.json
+__dummy.html
+docs/
+
+# DUB testing artifacts
+*-test-library
+*-test-application
+
+# Code coverage
+*.lst
+
+# Emacs
+*~


### PR DESCRIPTION
This repository cannot be used as a submodule because it does not ignore .a