### PR TITLE
Allowed copying of tagged unions containing unit values

### DIFF
--- a/source/taggedalgebraic/taggedunion.d
+++ b/source/taggedalgebraic/taggedunion.d
@@ -39,6 +39,7 @@ align(commonAlignment!(UnionKindTypes!(UnionFieldEnum!U))) struct TaggedUnion
 {
 	import std.traits : FieldTypeTuple, FieldNameTuple, Largest,
 		hasElaborateCopyConstructor, hasElaborateDestructor, isCopyable;
+	import std.meta : templateOr;
 	import std.ascii : toUpper;
 
 	alias FieldDefinitionType = U;
@@ -104,7 +105,7 @@ align(commonAlignment!(UnionKindTypes!(UnionFieldEnum!U))) struct TaggedUnion
 	}
 
 	// postblit constructor
-	static if (!allSatisfy!(isCopyable, FieldTypes)) {
+	static if (!allSatisfy!(templateOr!(isCopyable, isUnitType), FieldTypes)) {
 		@disable this(this);
 	} else static if (anySatisfy!(hasElaborateCopyConstructor, FieldTypes)) {
 		this(this)


### PR DESCRIPTION
A tagged union intantiated from an `enum` was not copyable, because `isCopyable!void == false`. There's no reason why such unions should not be copyable, though. This fixes it at least for me.