### PR TITLE
meson: fix build on macOS

### DIFF
--- a/source/taggedalgebraic/meson.build
+++ b/source/taggedalgebraic/meson.build
@@ -4,13 +4,23 @@ taggedalgebraic_src = [
 	'visit.d',
 ]
 
-taggedalgebraic_lib = library(
-	'taggedalgebraic',
-	taggedalgebraic_src,
-	version: project_version,
-	install: true,
-	include_directories: include_directories('../')
-)
+# https://github.com/mesonbuild/meson/issues/6862
+if build_machine.system() == 'darwin'
+	taggedalgebraic_lib = library(
+		'taggedalgebraic',
+		taggedalgebraic_src,
+		install: true,
+		include_directories: include_directories('../'),
+	)
+else
+	taggedalgebraic_lib = library(
+		'taggedalgebraic',
+		taggedalgebraic_src,
+		install: true,
+		include_directories: include_directories('../'),
+		version: project_version,
+	)
+endif
 
 pkgc = import('pkgconfig')
 


### PR DESCRIPTION
Seems like the macOS linker doesn't like the version number as dylib version.

ref  https://github.com/mesonbuild/meson/issues/6862