### PR TITLE
Avoid instantiating generic visitor with types it cannot handle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ TaggedAlgebraic
 
 Implementation of a generic `TaggedUnion` type along with a `TaggedAlgebraic` type that forwards all methods and operators of the contained types using dynamic dispatch.
 
-[![Build Status](https://travis-ci.org/s-ludwig/taggedalgebraic.svg?branch=master)](https://travis-ci.org/s-ludwig/taggedalgebraic) [![codecov](https://codecov.io/gh/s-ludwig/taggedalgebraic/branch/master/graph/badge.svg)](https://codecov.io/gh/s-ludwig/taggedalgebraic)
+[![Build Status](https://travis-ci.com/s-ludwig/taggedalgebraic.svg?branch=master)](https://travis-ci.com/s-ludwig/taggedalgebraic) [![codecov](https://codecov.io/gh/s-ludwig/taggedalgebraic/branch/master/graph/badge.svg)](https://codecov.io/gh/s-ludwig/taggedalgebraic)
 
 API Documentation:
  - [`taggedalgebraic`](https://vibed.org/api/taggedalgebraic.taggedalgebraic/)

--- a/source/taggedalgebraic/visit.d
+++ b/source/taggedalgebraic/visit.d
@@ -217,13 +217,23 @@ private template matchesType(alias fun) {
 			else static if (Params.length == 1 && is(T == Params[0])) enum matchesType = true;
 			else enum matchesType = false;
 		} else static if (!isUnitType!T) {
-			static if (isSomeFunction!(fun!T)) {
+			static if (__traits(compiles, fun!T) && isSomeFunction!(fun!T)) {
 				alias Params = ParameterTypeTuple!(fun!T);
 				static if (Params.length == 1 && is(T == Params[0])) enum matchesType = true;
 				else enum matchesType = false;
 			} else enum matchesType = false;
 		} else enum matchesType = false;
 	}
+}
+
+unittest {
+	class C {}
+	alias mt1 = matchesType!((C c) => true);
+	alias mt2 = matchesType!((c) { static assert(!is(typeof(c) == C)); });
+	static assert(mt1!C);
+	static assert(!mt1!int);
+	static assert(mt2!int);
+	static assert(!mt2!C);
 }
 
 private template selectHandler(T, VISITORS...)


### PR DESCRIPTION
In cases where statically typed visitors need to be defined to avoid compile errors in a generic visitor, the generic one was still instantiated with the types already handled by the statically typed one(s), possibly resulting in a compile error.