### PR TITLE
Add support for upcoming '-preview=in' switch

### DIFF
--- a/source/taggedalgebraic/taggedalgebraic.d
+++ b/source/taggedalgebraic/taggedalgebraic.d
@@ -627,7 +627,7 @@ unittest
 
 /** Tests if the algebraic type stores a value of a certain data type.
 */
-bool hasType(T, U)(in ref TaggedAlgebraic!U ta)
+bool hasType(T, U)(const scope ref TaggedAlgebraic!U ta)
 {
 	alias Fields = Filter!(fieldMatchesType!(U, T), ta.m_union.fieldNames);
 	static assert(Fields.length > 0, "Type "~T.stringof~" cannot be stored in a "~(TaggedAlgebraic!U).stringof~".");
@@ -641,7 +641,7 @@ bool hasType(T, U)(in ref TaggedAlgebraic!U ta)
 	assert(false); // never reached
 }
 /// ditto
-bool hasType(T, U)(in TaggedAlgebraic!U ta)
+bool hasType(T, U)(const scope TaggedAlgebraic!U ta)
 {
 	return hasType!(T, U)(ta);
 }


### PR DESCRIPTION
Since taggedalgebraic is a dependency of many projects,
as it's a dependency of Vibe.d, adding support for this switch
will allow to run the tests for many more project before merging
the PR.
See dlang/dmd#11000.