### PR TITLE
Work around DMD bug 21235.

### DIFF
--- a/source/taggedalgebraic/taggedalgebraic.d
+++ b/source/taggedalgebraic/taggedalgebraic.d
@@ -116,8 +116,23 @@ struct TaggedAlgebraic(U) if (is(U == union) || is(U == struct) || is(U == enum)
 	}
 
 	/// Enables equality comparison with the stored value.
-	auto ref opEquals(T, this TA)(auto ref T other)
-		if (is(Unqual!T == TaggedAlgebraic) || hasOp!(TA, OpKind.binary, "==", T))
+	// no "this TA" due to https://issues.dlang.org/show_bug.cgi?id=21235
+	auto ref opEquals(T)(auto ref T other)
+		if (is(Unqual!T == TaggedAlgebraic) || hasOp!(typeof(this), OpKind.binary, "==", T))
+	{
+		static if (is(Unqual!T == TaggedAlgebraic)) {
+			return m_union == other.m_union;
+		} else return implementOp!(OpKind.binary, "==")(this, other);
+	}
+	auto ref opEquals(T)(auto ref T other) const
+		if (is(Unqual!T == TaggedAlgebraic) || hasOp!(typeof(this), OpKind.binary, "==", T))
+	{
+		static if (is(Unqual!T == TaggedAlgebraic)) {
+			return m_union == other.m_union;
+		} else return implementOp!(OpKind.binary, "==")(this, other);
+	}
+	auto ref opEquals(T)(auto ref T other) immutable
+		if (is(Unqual!T == TaggedAlgebraic) || hasOp!(typeof(this), OpKind.binary, "==", T))
 	{
 		static if (is(Unqual!T == TaggedAlgebraic)) {
 			return m_union == other.m_union;


### PR DESCRIPTION
I don't understand why this helps, I don't understand 21235 and I don't understand what DMD is doing with 'this TA' that doesn't happen if I leave it out.
But I get a linker error with 'this TA' in 'opEquals' specifically. If I write all three forms of opEquals manually, I don't get a linker error.
Sorry I don't have anything better here.

(Standing theory: DMD internally tries to instantiate `opEquals` to fill in the `TypeInfo` for `TaggedAlgebraic`. If there is one template, then a recursion comes up somewhere that connects the same `opEquals` instance with itself. Then, some time later, DMD finds an error after all in that instance (this is swallowed because `xopEquals` gags errors) - but the `TypeInfo` method is already declared error-free and is emitted later, with a dangling reference (due to error) to the `opEquals` instance. And ... splitting up the opEquals makes that not happen ... because ... I don't know, okay? It just does.)