### PR TITLE
Avoid unreachable code error

### DIFF
--- a/source/taggedalgebraic/taggedalgebraic.d
+++ b/source/taggedalgebraic/taggedalgebraic.d
@@ -1350,7 +1350,6 @@ private string generateConstructors(U)()
 			this(UnionType.FieldTypeByName!"%1$s" value, Kind type)
 			{
 				switch (type) {
-					default: assert(false, format("Invalid type ID for type %%s: %%s", UnionType.FieldTypeByName!"%1$s".stringof, type));
 					foreach (i, n; TaggedUnion!U.fieldNames) {
 						static if (is(UnionType.FieldTypeByName!"%1$s" == UnionType.FieldTypes[i])) {
 							case __traits(getMember, Kind, n):
@@ -1360,6 +1359,7 @@ private string generateConstructors(U)()
 								return;
 						}
 					}
+					default: assert(false, format("Invalid type ID for type %%s: %%s", UnionType.FieldTypeByName!"%1$s".stringof, type));
 				}
 			}
 		}.format(tname);

--- a/source/taggedalgebraic/taggedalgebraic.d
+++ b/source/taggedalgebraic/taggedalgebraic.d
@@ -1359,6 +1359,8 @@ private string generateConstructors(U)()
 								return;
 						}
 					}
+					// NOTE: the default case needs to be at the bottom to avoid bogus
+					//       unreachable code warnings (DMD issue 21671)
 					default: assert(false, format("Invalid type ID for type %%s: %%s", UnionType.FieldTypeByName!"%1$s".stringof, type));
 				}
 			}


### PR DESCRIPTION
An error complaining about m_union not being set cropped up in our codebase.
This change fixes it by putting the case in which it is not set at the end