### PR TITLE
build: provide 'source' target in meson build file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('taggedalgebraic', 'd',
-	meson_version: '>=0.50',
+	meson_version: '>=0.54',
 	version: '0.11.20'
 )
 
@@ -16,3 +16,10 @@ taggedalgebraic_dep = declare_dependency(
 	include_directories: include_directories('source'),
 	link_with: taggedalgebraic_lib
 )
+
+taggedalgebraic_source_dep = declare_dependency(
+	version: project_version,
+	include_directories: '../'
+)
+
+meson.override_dependency('taggedalgebraic', taggedalgebraic_dep)

--- a/source/taggedalgebraic/meson.build
+++ b/source/taggedalgebraic/meson.build
@@ -3,7 +3,6 @@ taggedalgebraic_src = [
 	'taggedalgebraic.d',
 	'taggedunion.d',
 	'visit.d',
-	'package.d'
 ]
 
 # https://github.com/mesonbuild/meson/issues/6862

--- a/source/taggedalgebraic/meson.build
+++ b/source/taggedalgebraic/meson.build
@@ -3,6 +3,7 @@ taggedalgebraic_src = [
 	'taggedalgebraic.d',
 	'taggedunion.d',
 	'visit.d',
+	'package.d'
 ]
 
 # https://github.com/mesonbuild/meson/issues/6862


### PR DESCRIPTION
This makes it possible to use '-i' while building with meson

Also: override_dependency makes it easier to wrap, but needs a meson bump to 0.54