### PR TITLE
Fix type system (const/inout) breach.

### DIFF
--- a/source/taggedalgebraic/taggedunion.d
+++ b/source/taggedalgebraic/taggedunion.d
@@ -275,7 +275,7 @@ align(commonAlignment!(UnionKindTypes!(UnionFieldEnum!U))) struct TaggedUnion
 
 		See_Also: `set`, `opAssign`
 	*/
-	@property ref inout(FieldTypes[kind]) value(Kind kind)()
+	@property ref value(Kind kind)()
 	inout {
 		if (this.kind != kind) {
 			enum msg(.string k_is) = "Attempt to get kind "~kind.stringof~" from tagged union with kind "~k_is;
@@ -285,8 +285,7 @@ align(commonAlignment!(UnionKindTypes!(UnionFieldEnum!U))) struct TaggedUnion
 						assert(false, msg!n);
 			}
 		}
-		//return trustedGet!(FieldTypes[kind]);
-		return *() @trusted { return cast(const(FieldTypes[kind])*)m_data.ptr; } ();
+		return trustedGet!(FieldTypes[kind]);
 	}
 
 
@@ -604,6 +603,22 @@ nothrow unittest {
 	TU tu, tv;
 	tu = S.init;
 	tv = tu;
+}
+
+unittest {
+	static struct S1 { int num; }
+	alias T1 = TaggedUnion!S1;
+	static assert(is(const(T1) : T1));
+	static assert(is(typeof(T1.init.value!int) == int));
+	static assert(is(typeof(T1.init.value!(T1.Kind.num)) == int));
+	static assert(is(typeof(T1.init.numValue) == int));
+	static assert(is(typeof(const(T1).init.value!int) == const(int)));
+	static assert(is(typeof(const(T1).init.value!(T1.Kind.num)) == const(int)));
+	static assert(is(typeof(const(T1).init.numValue) == const(int)));
+
+	static struct S2 { int[] nums; }
+	alias T2 = TaggedUnion!S2;
+	static assert(!is(const(T2) : T2));
 }
 
 

--- a/source/taggedalgebraic/visit.d
+++ b/source/taggedalgebraic/visit.d
@@ -3,7 +3,7 @@ module taggedalgebraic.visit;
 import taggedalgebraic.taggedalgebraic;
 import taggedalgebraic.taggedunion;
 
-import std.meta : anySatisfy;
+import std.meta : anySatisfy, staticMap;
 import std.traits : EnumMembers, isInstanceOf;
 
 
@@ -35,7 +35,7 @@ template visit(VISITORS...)
 						alias T = void;
 					else alias T = TU.FieldTypes[k];
 					alias h = selectHandler!(T, VISITORS);
-					static if (is(typeof(h) == typeof(null))) static assert(false, "No visitor defined for type type "~T.stringof);
+					static if (is(typeof(h) == typeof(null))) static assert(false, "No visitor defined for type "~T.stringof);
 					else static if (is(typeof(h) == string)) static assert(false, h);
 					else static if (is(T == void)) return h();
 					else return h(tu.value!k);
@@ -143,6 +143,38 @@ unittest {
 	);
 }
 
+unittest {
+	static struct S {
+		int num;
+		int[] nums;
+	}
+	alias TU = TaggedUnion!S;
+
+	TU tu = [1];
+	tu.visit!(
+		(int num) { assert(false); },
+		(int[] num) { assert(num == [1]); }
+	);
+	tu.visit!(
+		(const int num) { assert(false); },
+		(const int[] num) { assert(num == [1]); }
+	);
+	tu.visit!(
+		(const int num) { assert(false); },
+		(const(int)[] num) { assert(num == [1]); }
+	);
+
+	const(TU) tuc = TU([1]);
+	tuc.visit!(
+		(int num) { assert(false); },
+		(const(int)[] num) { assert(num == [1]); }
+	);
+	tuc.visit!(
+		(const(int) num) { assert(false); },
+		(const(int[]) num) { assert(num == [1]); }
+	);
+}
+
 
 /** The same as `visit`, except that failure to handle types is checked at runtime.
 
@@ -210,14 +242,15 @@ unittest {
 
 private template validateHandlers(TU, VISITORS...)
 {
-	import std.traits : isSomeFunction;
+	import std.traits : CopyConstness, isSomeFunction;
 
-	alias Types = TU.FieldTypes;
+	alias ApplyConst(T) = CopyConstness!(TU, T);
+	alias Types = staticMap!(ApplyConst, TU.FieldTypes);
 
 	static foreach (int i; 0 .. VISITORS.length) {
 		static if (isSomeFunction!(VISITORS[i])) {
 			static assert(anySatisfy!(matchesType!(VISITORS[i]), Types),
-				"Visitor at index "~i.stringof~" does not match any type of "~TU.FieldTypes.stringof);
+				"Visitor at index "~i.stringof~" does not match any type of "~Types.stringof);
 		} else {
 			static assert(__traits(isTemplate, VISITORS[i]),
 				"Visitor at index "~i.stringof~" must be a function/delegate literal: "~VISITORS[i].stringof);
@@ -232,12 +265,12 @@ private template matchesType(alias fun) {
 		static if (isSomeFunction!fun) {
 			alias Params = ParameterTypeTuple!fun;
 			static if (Params.length == 0 && isUnitType!T) enum matchesType = true;
-			else static if (Params.length == 1 && is(T == Params[0])) enum matchesType = true;
+			else static if (Params.length == 1 && isMatch!(Params[0], T)) enum matchesType = true;
 			else enum matchesType = false;
 		} else static if (!isUnitType!T) {
 			static if (__traits(compiles, fun!T) && isSomeFunction!(fun!T)) {
 				alias Params = ParameterTypeTuple!(fun!T);
-				static if (Params.length == 1 && is(T == Params[0])) enum matchesType = true;
+				static if (Params.length == 1 && isMatch!(Params[0], T)) enum matchesType = true;
 				else enum matchesType = false;
 			} else enum matchesType = false;
 		} else enum matchesType = false;
@@ -254,6 +287,11 @@ unittest {
 	static assert(!mt2!C);
 }
 
+template isMatch(PT, T) {
+	import std.traits : Unqual;
+	enum isMatch = is(Unqual!(immutable(T)) == Unqual!(immutable(PT))) && is(T : PT);
+}
+
 private template selectHandler(T, VISITORS...)
 {
 	import std.traits : ParameterTypeTuple, isSomeFunction;
@@ -264,7 +302,7 @@ private template selectHandler(T, VISITORS...)
 			static if (isSomeFunction!fun) {
 				alias Params = ParameterTypeTuple!fun;
 				static if (Params.length > 1) enum typedIndex = "Visitor at index "~i.stringof~" must not take more than one parameter.";
-				else static if (Params.length == 0 && is(T == void) || Params.length == 1 && is(T == Params[0])) {
+				else static if (Params.length == 0 && is(T == void) || Params.length == 1 && isMatch!(Params[0], T)) {
 					static if (matched_index >= 0) enum typedIndex = "Vistor at index "~i.stringof~" conflicts with visitor at index "~matched_index~".";
 					else enum typedIndex = typedIndex!(i+1, i);
 				} else enum typedIndex = typedIndex!(i+1, matched_index);


### PR DESCRIPTION
value!kind was always returning non-const references, regardless of the attributes of `this`, due to a compiler bug. Using `trustedGet` together with return type inference appears to work correctly on the other hand.