### PR TITLE
Modernize Meson script

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,10 +12,10 @@ taggedalgebraic_dep = declare_dependency(
 )
 
 test_exe = executable(
-	'taggedalgebraic_test',
-	dependencies: taggedalgebraic_dep,
-	d_unittest: true,
-	link_args: '-main',
+    'taggedalgebraic_test',
+    dependencies: taggedalgebraic_dep,
+    d_unittest: true,
+    link_args: '-main',
 )
 
 test('test_taggedalgebraic', test_exe)

--- a/meson.build
+++ b/meson.build
@@ -1,25 +1,21 @@
-project('taggedalgebraic', 'd',
-	meson_version: '>=0.54',
-	version: '0.11.20'
+project(
+    'taggedalgebraic',
+    ['d'],
+    meson_version: '>=1.3.1',
 )
 
-project_soversion      = '0'
-project_version_suffix = ''
-project_version        = meson.project_version()
-project_version_full   = project_version + project_version_suffix
-
-source_root = meson.source_root()
-build_root = meson.build_root()
 subdir('source/taggedalgebraic')
 
 taggedalgebraic_dep = declare_dependency(
-	include_directories: include_directories('source'),
-	link_with: taggedalgebraic_lib
+    sources: taggedalgebraic_src,
+    include_directories: taggedalgebraic_includes,
 )
 
-taggedalgebraic_source_dep = declare_dependency(
-	version: project_version,
-	include_directories: '../'
+test_exe = executable(
+	'taggedalgebraic_test',
+	dependencies: taggedalgebraic_dep,
+	d_unittest: true,
+	link_args: '-main',
 )
 
-meson.override_dependency('taggedalgebraic', taggedalgebraic_dep)
+test('test_taggedalgebraic', test_exe)

--- a/source/taggedalgebraic/meson.build
+++ b/source/taggedalgebraic/meson.build
@@ -1,46 +1,8 @@
-taggedalgebraic_src = [
+taggedalgebraic_src = files(
 	'package.d',
 	'taggedalgebraic.d',
 	'taggedunion.d',
 	'visit.d',
-]
-
-# https://github.com/mesonbuild/meson/issues/6862
-if build_machine.system() == 'darwin'
-	taggedalgebraic_lib = library(
-		'taggedalgebraic',
-		taggedalgebraic_src,
-		install: true,
-		include_directories: include_directories('../'),
-	)
-else
-	taggedalgebraic_lib = library(
-		'taggedalgebraic',
-		taggedalgebraic_src,
-		install: true,
-		include_directories: include_directories('../'),
-		version: project_version,
-	)
-endif
-
-pkgc = import('pkgconfig')
-
-pkgc.generate(
-	taggedalgebraic_lib,
-	subdirs: 'd/taggedalgebraic',
 )
 
-install_headers(
-	taggedalgebraic_src,
-	subdir: 'd/taggedalgebraic/taggedalgebraic',
-)
-
-test_exe = executable(
-	'taggedalgebraic_test',
-	taggedalgebraic_src,
-	include_directories: include_directories('../'),
-	d_unittest: true,
-	link_args: '-main',
-)
-
-test('test_taggedalgebraic', test_exe)
+taggedalgebraic_includes = include_directories('..')

--- a/travis.sh
+++ b/travis.sh
@@ -12,6 +12,6 @@ else
     dub test
 
     if [ "x${TEST_MESON:-}" = "xtrue" ] && [ "x$(dmd --version | head -n1)" != "xDMD64 D Compiler v2.085.1" ]; then
-        meson build && ninja -C build
+        meson setup build/ && ninja -C build/
     fi
 fi


### PR DESCRIPTION
* Removes `project_version` and Co - Meson suggests different way to establish version compliance

* Removes install stuff - we don't need install this small source library (we do not need to be able to install every package from code.dlang.org in a row)

* Removes the meaningless division of deps variables to "source" or not

* Removes `pkgconfig` stuff (why and whom was need this?)

* Removes unnecessary for now `build_machine.system()` branch for MacOS