### PR TITLE
Remove (unintended) move constructor that causes compile errors on DMD 2.111.0

### DIFF
--- a/source/taggedalgebraic/taggedunion.d
+++ b/source/taggedalgebraic/taggedunion.d
@@ -70,11 +70,6 @@ align(commonAlignment!(UnionKindTypes!(UnionFieldEnum!U))) struct TaggedUnion
 		Kind m_kind;
 	}
 
-	this(TaggedUnion other)
-	{
-		rawSwap(this, other);
-	}
-
 	void opAssign(TaggedUnion other)
 	{
 		rawSwap(this, other);


### PR DESCRIPTION
This constructor was there before move constructors where a thing and now causes errors in druntime when a TaggedUnion is nested in another struct and an array of that struct is ".dup"ed.