### PR TITLE
Decrease compile time

### DIFF
--- a/source/taggedalgebraic/taggedunion.d
+++ b/source/taggedalgebraic/taggedunion.d
@@ -752,11 +752,18 @@ package template AmbiguousTypes(Types...) {
 	alias AmbiguousTypes = impl!0;
 }
 
+private size_t gcd(size_t a, size_t b) {
+    while (b != 0) {
+        size_t temp = b;
+        b = a % b;
+        a = temp;
+    }
+    return a;
+}
+
 /// Computes the minimum alignment necessary to align all types correctly
 private size_t commonAlignment(TYPES...)()
 {
-	import std.numeric : gcd;
-
 	size_t ret = 1;
 	foreach (T; TYPES)
 		ret = (T.alignof * ret) / gcd(T.alignof, ret);


### PR DESCRIPTION
std.format and std.numeric.gcd shows up quite heavily during tracing compile times.
This PR removes two expansive format calls and introduces a super simple gcd algorithm.

Below are two traces building vibe.d with and without the changes. With the change compilation is about 7% faster on my machine.
[trace_baseline.json](https://github.com/user-attachments/files/21531873/trace_baseline.json)
[trace.json](https://github.com/user-attachments/files/21531874/trace.json)

 I'm a big std.format fan, but its compile time is just bad.